### PR TITLE
Support for database insights config

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -9,7 +9,7 @@ resource "aws_kms_key" "rds" {
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 module "aurora_serverless_v2" {
   source  = "cloudposse/rds-cluster/aws"
-  version = "2.4.0"
+  version = "2.5.0"
 
   name           = var.rds_cluster_name == "" ? "rds-${local.name_string}" : var.rds_cluster_name
   engine         = var.rds_config.engine
@@ -52,6 +52,9 @@ module "aurora_serverless_v2" {
   ## Monitoring
   rds_monitoring_interval          = var.rds_monitoring_interval
   enhanced_monitoring_role_enabled = var.rds_monitoring_role_enabled
+
+  ## Instance identifier suffix - keep empty to avoid random pet name generation
+  instance_identifier_suffix = ""
 
   ## Performance Insights
   performance_insights_enabled          = var.rds_performance

--- a/rds.tf
+++ b/rds.tf
@@ -9,7 +9,7 @@ resource "aws_kms_key" "rds" {
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 module "aurora_serverless_v2" {
   source  = "cloudposse/rds-cluster/aws"
-  version = "1.6.0"
+  version = "2.4.0"
 
   name           = var.rds_cluster_name == "" ? "rds-${local.name_string}" : var.rds_cluster_name
   engine         = var.rds_config.engine

--- a/rdsauth.tf
+++ b/rdsauth.tf
@@ -61,7 +61,7 @@ resource "aws_secretsmanager_secret" "dbsecret_extra" {
   name        = "rds-${local.name_string}-extra"
   kms_key_id  = aws_kms_key.rds_secret_kms_key.arn
   tags        = var.rds_tags
-  
+
   recovery_window_in_days = 0
 }
 


### PR DESCRIPTION
This PR upgrades to the latest version of the community module (2.5.0). This version introduces management of the RDS monitoring on cluster level. Also, it creates IPv6 outbound rule (we already have ipv4 outbound rule). It cannot be disabled based on the community module, but it will not affect the production environments.